### PR TITLE
Patch for https://github.com/plone/plone.keyring/issues/1

### DIFF
--- a/plone/keyring/keymanager.py
+++ b/plone/keyring/keymanager.py
@@ -1,3 +1,4 @@
+import zope.event
 from persistent.mapping import PersistentMapping
 from zope.container.sample import SampleContainer
 from zope.interface import implements
@@ -11,8 +12,11 @@ class KeyManager(SampleContainer):
 
     def __init__(self):
         SampleContainer.__init__(self)
+        subscribers = zope.event.subscribers[:]
+        del zope.event.subscribers[:]
         self[u"_system"]=Keyring()
         self[u"_system"].rotate()
+        zope.event.subscribers[:] = subscribers
 
 
     def _newContainerData(self):


### PR DESCRIPTION
Fixed: When using utility from the package 'zope.intids', create an instance of KeyManager raises an exception 'zope.keyreference.interfaces.NotYet'.
